### PR TITLE
Bybit updates (ws conn & data) for coinmarginedfutures

### DIFF
--- a/exchanges/bybit/bybit_types.go
+++ b/exchanges/bybit/bybit_types.go
@@ -555,16 +555,16 @@ type WsFuturesOrderbook struct {
 // WsUSDTOrderbook stores ws usdt orderbook
 type WsUSDTOrderbook struct {
 	Topic string `json:"topic"`
-	Type  string `json:"string"`
+	Type  string `json:"type"`
 	Data  struct {
 		OBData []WsFuturesOrderbookData `json:"order_book"`
 	} `json:"data"`
 }
 
-// WsCoinDeltaOrderbook stores ws coinmargined orderbook
-type WsCoinDeltaOrderbook struct {
+// WsFuturesDeltaOrderbook stores ws futures orderbook deltas
+type WsFuturesDeltaOrderbook struct {
 	Topic  string `json:"topic"`
-	Type   string `json:"string"`
+	Type   string `json:"type"`
 	OBData struct {
 		Delete []WsFuturesOrderbookData `json:"delete"`
 		Update []WsFuturesOrderbookData `json:"update"`
@@ -663,7 +663,7 @@ type WsTicker struct {
 // WsDeltaTicker stores ws ticker
 type WsDeltaTicker struct {
 	Topic string `json:"topic"`
-	Type  string `json:"string"`
+	Type  string `json:"type"`
 	Data  struct {
 		Delete []WsTickerData `json:"delete"`
 		Update []WsTickerData `json:"update"`
@@ -723,12 +723,14 @@ type WsFuturesTicker struct {
 // WsDeltaFuturesTicker stores ws delta future ticker
 type WsDeltaFuturesTicker struct {
 	Topic string `json:"topic"`
-	Type  string `json:"string"`
+	Type  string `json:"type"`
 	Data  struct {
 		Delete []WsFuturesTickerData `json:"delete"`
 		Update []WsFuturesTickerData `json:"update"`
 		Insert []WsFuturesTickerData `json:"insert"`
 	} `json:"data"`
+	CrossSeq  int64     `json:"coss_seq"`
+	Timestamp bybitTime `json:"timestamp_e6"`
 }
 
 // WsLiquidationData stores ws liquidation data

--- a/exchanges/bybit/bybit_wrapper.go
+++ b/exchanges/bybit/bybit_wrapper.go
@@ -234,8 +234,9 @@ func (by *Bybit) Setup(exch *config.Exchange) error {
 	}
 	if by.IsAssetWebsocketSupported(asset.USDTMarginedFutures) {
 		usdtMarginedFuturesWebsocket, err := by.Websocket.AddWebsocket(&stream.WebsocketSetup{
-			DefaultURL:            bybitWebsocketCoinMarginedFuturesPublicV2,
-			RunningURL:            bybitWebsocketCoinMarginedFuturesPublicV2,
+			DefaultURL:            bybitWebsocketUSDTMarginedFuturesPublicV2,
+			RunningURL:            bybitWebsocketUSDTMarginedFuturesPublicV2,
+			RunningURLAuth:        bybitWebsocketUSDTMarginedFuturesPrivateV2,
 			Connector:             by.WsUSDTConnect,
 			Subscriber:            by.SubscribeUSDT,
 			Unsubscriber:          by.UnsubscribeUSDT,
@@ -246,7 +247,7 @@ func (by *Bybit) Setup(exch *config.Exchange) error {
 			return err
 		}
 		err = usdtMarginedFuturesWebsocket.SetupNewConnection(stream.ConnectionSetup{
-			URL:                  bybitWebsocketCoinMarginedFuturesPublicV2,
+			URL:                  bybitWebsocketUSDTMarginedFuturesPublicV2,
 			ResponseCheckTimeout: exch.WebsocketResponseCheckTimeout,
 			ResponseMaxLimit:     exch.WebsocketResponseMaxLimit,
 		})
@@ -254,7 +255,7 @@ func (by *Bybit) Setup(exch *config.Exchange) error {
 			return err
 		}
 		err = usdtMarginedFuturesWebsocket.SetupNewConnection(stream.ConnectionSetup{
-			URL:                  bybitWebsocketUSDTMarginedFuturesPublicV2,
+			URL:                  bybitWebsocketUSDTMarginedFuturesPrivateV2,
 			ResponseCheckTimeout: exch.WebsocketResponseCheckTimeout,
 			ResponseMaxLimit:     exch.WebsocketResponseMaxLimit,
 			Authenticated:        true,
@@ -302,6 +303,15 @@ func (by *Bybit) Setup(exch *config.Exchange) error {
 			URL:                  bybitWebsocketCoinMarginedFuturesPublicV2,
 			ResponseCheckTimeout: exch.WebsocketResponseCheckTimeout,
 			ResponseMaxLimit:     exch.WebsocketResponseMaxLimit,
+		})
+		if err != nil {
+			return err
+		}
+		err = futuresWebsocket.SetupNewConnection(stream.ConnectionSetup{
+			URL:                  bybitWebsocketCoinMarginedFuturesPublicV2,
+			ResponseCheckTimeout: exch.WebsocketResponseCheckTimeout,
+			ResponseMaxLimit:     exch.WebsocketResponseMaxLimit,
+			Authenticated:        true,
 		})
 		if err != nil {
 			return err

--- a/exchanges/bybit/bybit_ws_futures.go
+++ b/exchanges/bybit/bybit_ws_futures.go
@@ -296,7 +296,7 @@ func (by *Bybit) wsFuturesHandleData(respRaw []byte) error {
 					return err
 				}
 			case wsOperationDelta:
-				var response WsCoinDeltaOrderbook
+				var response WsFuturesDeltaOrderbook
 				err = json.Unmarshal(respRaw, &response)
 				if err != nil {
 					return err


### PR DESCRIPTION
Bybit - Update ws connection to coinmarginedfutures (inverse perpetual) 

Public endpoints only

- Add auth connection for Coin
- Route connections through funnel for Coin
- Subscription and sub generation update
- Data types update
- Topic check moved
- Ticker updates:
  - According to spec, Delete and Insert are not used.
  - No need to FetchTicker(), since there has been an initial snapshot.
  - Removed the check for changed values, since Bybit only sends chanced valued
  - Removed `bool checked` (though this can in theory lead to relaying tickers where only the timestamp has changed)
- Set correct ws endpoint for USDT

## How has this been tested

Tested by running the ticker stream, ob stream and getting trade data.
