### PR TITLE
Bybit - handle websocket response messages (coinmarginedfutures)

### DIFF
--- a/exchanges/bybit/bybit_types.go
+++ b/exchanges/bybit/bybit_types.go
@@ -348,10 +348,26 @@ type WsReq struct {
 	Parameters interface{} `json:"params"`
 }
 
+// WsResp stores futures ws response
+type WsResp struct {
+	Success bool   `json:"success"`
+	RetMsg  string `json:"ret_msg"`
+	ConnID  string `json:"conn_id"`
+	Request WsReq  `json:"request"`
+}
+
 // WsFuturesReq stores futures ws request
 type WsFuturesReq struct {
 	Topic string   `json:"op"`
 	Args  []string `json:"args"`
+}
+
+// WsFuturesResp stores futures ws response
+type WsFuturesResp struct {
+	Success bool         `json:"success"`
+	RetMsg  string       `json:"ret_msg"`
+	ConnID  string       `json:"conn_id"`
+	Request WsFuturesReq `json:"request"`
 }
 
 // WsParams store ws parameters
@@ -696,7 +712,7 @@ type WsLiquidationData struct {
 	Symbol    string                  `json:"symbol"`
 	Side      string                  `json:"side"`
 	Price     convert.StringToFloat64 `json:"price"`
-	Qty       float64                 `json:"qty"`
+	Qty       convert.StringToFloat64 `json:"qty"`
 	Timestamp bybitTime               `json:"time"`
 }
 

--- a/exchanges/bybit/bybit_ws_futures.go
+++ b/exchanges/bybit/bybit_ws_futures.go
@@ -172,7 +172,7 @@ func (by *Bybit) SubscribeFutures(channelsToSubscribe []stream.ChannelSubscripti
 	var errs error
 	for i := range channelsToSubscribe {
 		var sub WsFuturesReq
-		sub.Topic = subscribe
+		sub.Topic = wsSubscribe
 
 		sub.Args = append(sub.Args, formatArgs(channelsToSubscribe[i].Channel, channelsToSubscribe[i].Params))
 		switch channelsToSubscribe[i].Channel {
@@ -198,7 +198,7 @@ func (by *Bybit) UnsubscribeFutures(channelsToUnsubscribe []stream.ChannelSubscr
 	var errs error
 	for i := range channelsToUnsubscribe {
 		var unSub WsFuturesReq
-		unSub.Topic = unsubscribe
+		unSub.Topic = wsUnsubscribe
 
 		formattedPair, err := by.FormatExchangeCurrency(channelsToUnsubscribe[i].Currency, asset.Futures)
 		if err != nil {
@@ -253,7 +253,7 @@ func (by *Bybit) wsFuturesHandleData(respRaw []byte) error {
 	t, ok := multiStreamData["topic"].(string)
 	if !ok {
 		if by.Verbose {
-			log.Warnf(log.ExchangeSys, "%s Asset Type %v Received unhandle message on websocket: %v\n", by.Name, asset.Futures, multiStreamData)
+			log.Warnf(log.ExchangeSys, "%s Asset Type %v Received unhandled message on websocket: %v\n", by.Name, asset.Futures, multiStreamData)
 		}
 		return nil
 	}

--- a/exchanges/bybit/bybit_ws_ufutures.go
+++ b/exchanges/bybit/bybit_ws_ufutures.go
@@ -211,7 +211,7 @@ func (by *Bybit) SubscribeUSDT(channelsToSubscribe []stream.ChannelSubscription)
 	var errs error
 	for i := range channelsToSubscribe {
 		var sub WsFuturesReq
-		sub.Topic = subscribe
+		sub.Topic = wsSubscribe
 
 		argStr := formatArgs(channelsToSubscribe[i].Channel, channelsToSubscribe[i].Params)
 		switch channelsToSubscribe[i].Channel {
@@ -245,7 +245,7 @@ func (by *Bybit) UnsubscribeUSDT(channelsToUnsubscribe []stream.ChannelSubscript
 	var errs error
 	for i := range channelsToUnsubscribe {
 		var unSub WsFuturesReq
-		unSub.Topic = unsubscribe
+		unSub.Topic = wsUnsubscribe
 
 		formattedPair, err := by.FormatExchangeCurrency(channelsToUnsubscribe[i].Currency, asset.USDTMarginedFutures)
 		if err != nil {
@@ -273,7 +273,7 @@ func (by *Bybit) wsUSDTHandleData(respRaw []byte) error {
 	t, ok := multiStreamData["topic"].(string)
 	if !ok {
 		if by.Verbose {
-			log.Warnf(log.ExchangeSys, "%s Asset Type %v Received unhandle message on websocket: %v\n", by.Name, asset.USDTMarginedFutures, multiStreamData)
+			log.Warnf(log.ExchangeSys, "%s Asset Type %v Received unhandled message on websocket: %v\n", by.Name, asset.USDTMarginedFutures, multiStreamData)
 		}
 		return nil
 	}


### PR DESCRIPTION
Authentication timed out for me a couple of times, which is why I looked more closely at the auth response messages

`[WARN]  | EXCHANGE | 19/07/2023 15:54:03 | Bybit Asset Type coinmarginedfutures Received unhandled message on websocket: map[conn_id:... request:map[args:[... 1689774843000 0xdeadbeef op:auth] ret_msg:error:request expired success:false]`